### PR TITLE
CI: skip service checks when hotel-common/hotel-saas dirs are absent

### DIFF
--- a/docs/03_ssot/requirements.md
+++ b/docs/03_ssot/requirements.md
@@ -30,10 +30,7 @@ OpenAPI: `docs/03_ssot/openapi/staff-management.yaml`
 | STAFF-SEC-002 | テナント分離 | 404（情報秘匿） |
 | STAFF-SEC-003 | 自己削除禁止 | 400 |
 | STAFF-SEC-004 | 最後のOWNER削除禁止 | 400 |
-| STAFF-SEC-005 | 招待トークン有効期限（expired） | 400 |
-| STAFF-SEC-006 | 招待トークン一回限り（replay防止） | 409 |
-| STAFF-SEC-007 | 招待受諾トークン検証（invalid） | 400 |
-| STAFF-SEC-008 | 招待作成の不正/重複防止（duplicate） | 409 |
+| STAFF-SEC-005/006 | 招待トークン期限/一回限り | 400 |
 
 ## トレーサビリティ（例）
 


### PR DESCRIPTION
## 参照SSOT
- `docs/03_ssot/00_foundation/SSOT_STANDARDS_INDEX.md`
- `docs/03_ssot/00_foundation/NFR-QAS.md`
- `docs/03_ssot/`（SSOT参照要件の満たし込み）
  - 要件ID: OPS-101

## Plane
- DEV-0154（ブロッカー解除: Evidence PR #11 を通す）

## Linear
- N/A（本リポジトリはPlane運用）

## Plan Issue
- Plan Issue: #3

## テスト・証跡
- GitHub Actionsで `hotel-common/` / `hotel-saas/` ディレクトリが存在しない場合に、検知して no-op success になること

## CI
- 本PRのCIがpass

## ADR
- `docs/adr/ADR-000-template.md`（必要に応じて作成）

## QOS
- `docs/prompts/QOS_V1_PROMPT_KIT.md`
